### PR TITLE
(re)Allow building manpages from the README

### DIFF
--- a/README
+++ b/README
@@ -33,7 +33,7 @@ directory with the same name as the file you're trying to download.
 
 dtrx supports a number of options to mandate specific behavior:
 
-```manpage
+```
 -r, --recursive
    With this option, dtrx will search inside the archives you specify to see
    if any of the contents are themselves archives, and extract those as

--- a/README
+++ b/README
@@ -24,7 +24,6 @@
   You should have received a copy of the GNU General Public License along
   with this program; if not, see <http://www.gnu.org/licenses/>.
 
-:Version: 7.1
 :Manual section: 1
 
 ## SYNOPSIS

--- a/README
+++ b/README
@@ -2,30 +2,6 @@
 
 > cleanly extract many archive types
 
-:Author: Brett Smith <brettcsmith@brettcsmith.org>
-:Date:   2011-11-19
-:Copyright:
-
-  dtrx 7.1 is copyright © 2006-2011 Brett Smith and others.  Feel free to
-  send comments, bug reports, patches, and so on.  You can find the latest
-  version of dtrx on its home page at
-  <http://www.brettcsmith.org/2007/dtrx/>.
-
-  dtrx is free software; you can redistribute it and/or modify it under the
-  terms of the GNU General Public License as published by the Free Software
-  Foundation; either version 3 of the License, or (at your option) any
-  later version.
-
-  This program is distributed in the hope that it will be useful, but
-  WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-  Public License for more details.
-
-  You should have received a copy of the GNU General Public License along
-  with this program; if not, see <http://www.gnu.org/licenses/>.
-
-:Manual section: 1
-
 ## SYNOPSIS
 
 `dtrx [OPTIONS] ARCHIVE [ARCHIVE ...]`
@@ -118,3 +94,27 @@ dtrx supports a number of options to mandate specific behavior:
 --version
    Display dtrx's version, copyright, and license information.
 ```
+
+:Author: Brett Smith <brettcsmith@brettcsmith.org>
+:Date:   2011-11-19
+:Copyright:
+
+  dtrx 7.1 is copyright © 2006-2011 Brett Smith and others.  Feel free to
+  send comments, bug reports, patches, and so on.  You can find the latest
+  version of dtrx on its home page at
+  <http://www.brettcsmith.org/2007/dtrx/>.
+
+  dtrx is free software; you can redistribute it and/or modify it under the
+  terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any
+  later version.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+  Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program; if not, see <http://www.gnu.org/licenses/>.
+
+:Manual section: 1


### PR DESCRIPTION
Previously, the README file was in reStructuredText format. As the v6.5 entry in the NEWS file states, "The README is now written like a man page, and can be converted to a man page by using rst2man_." The conversion to a pypi-friendly format broke that.

I don't know what format the README is currently in - the nearest I can figure out is github-flavored markdown? Either way, pandoc doesn't properly convert it from gfm to rst in a form that rst2man understands. These patches make it at least work, although it's still not 100% proper. Ideally there would be an option to build the man page during build for distributions or non-pip installations.

Please let me know if I guessed the wrong format, and/or if there's a way to have python generate a .rst or manpage file.