### PR TITLE
Add rst2man checker to github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         python: [py27, py36, py37, py38, py39]
@@ -31,3 +31,22 @@ jobs:
         with:
           name: ${{ matrix.python }}-wheel-output
           path: .tox/${{ matrix.python }}/dist/
+
+  manpage:
+    runs-on: ubuntu-latest
+
+    steps:
+      # checkout v2, with recursive submodule update
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+
+      # build the Docker image we use to run the tests
+      - name: test.sh
+        run: RUN_JOB=rst2man ./test.sh
+
+      # upload-artifact to save the output wheels
+      - uses: actions/upload-artifact@v2
+        with:
+          name: manpage-output
+          path: dtrx.1

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build
 /.eggs/
 /*.egg-info/
 /dist/
+/dtrx.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ ENV PATH=${PATH}:/home/${UNAME}/.local/bin
 
 USER ${UNAME}
 
-# Need tox to run the tests
-RUN pip3 install tox==3.15.2
+# Need tox to run the tests, docutils for rst2man.py
+RUN pip3 install tox==3.15.2 docutils==0.16
 
 WORKDIR /mnt/workspace

--- a/README
+++ b/README
@@ -1,12 +1,24 @@
-# dtrx
+====
+dtrx
+====
 
-> cleanly extract many archive types
+----------------------------------
+cleanly extract many archive types
+----------------------------------
 
-## SYNOPSIS
+:Author: Brett Smith <brettcsmith@brettcsmith.org>
+:Date:   2011-11-19
+:Copyright: 2006-2011 Brett Smith and others
 
-`dtrx [OPTIONS] ARCHIVE [ARCHIVE ...]`
+:Manual section: 1
 
-## DESCRIPTION
+SYNOPSIS
+========
+
+dtrx [OPTIONS] ARCHIVE [ARCHIVE ...]
+
+DESCRIPTION
+===========
 
 dtrx extracts archives in a number of different formats; it currently
 supports tar, zip (including self-extracting .exe files), cpio, rpm, deb,
@@ -29,11 +41,11 @@ You may specify URLs as arguments as well.  If you do, dtrx will use `wget
 downloads.  This may fail if you already have a file in the current
 directory with the same name as the file you're trying to download.
 
-## OPTIONS
+OPTIONS
+=======
 
 dtrx supports a number of options to mandate specific behavior:
 
-```
 -r, --recursive
    With this option, dtrx will search inside the archives you specify to see
    if any of the contents are themselves archives, and extract those as
@@ -93,28 +105,24 @@ dtrx supports a number of options to mandate specific behavior:
 
 --version
    Display dtrx's version, copyright, and license information.
-```
 
-:Author: Brett Smith <brettcsmith@brettcsmith.org>
-:Date:   2011-11-19
-:Copyright:
+LICENSE
+=======
 
-  dtrx 7.1 is copyright © 2006-2011 Brett Smith and others.  Feel free to
-  send comments, bug reports, patches, and so on.  You can find the latest
-  version of dtrx on its home page at
-  <http://www.brettcsmith.org/2007/dtrx/>.
+dtrx 7.1 is copyright © 2006-2011 Brett Smith and others.  Feel free to
+send comments, bug reports, patches, and so on.  You can find the latest
+version of dtrx on its home page at
+<http://www.brettcsmith.org/2007/dtrx/>.
 
-  dtrx is free software; you can redistribute it and/or modify it under the
-  terms of the GNU General Public License as published by the Free Software
-  Foundation; either version 3 of the License, or (at your option) any
-  later version.
+dtrx is free software; you can redistribute it and/or modify it under the
+terms of the GNU General Public License as published by the Free Software
+Foundation; either version 3 of the License, or (at your option) any
+later version.
 
-  This program is distributed in the hope that it will be useful, but
-  WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
-  Public License for more details.
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.
 
-  You should have received a copy of the GNU General Public License along
-  with this program; if not, see <http://www.gnu.org/licenses/>.
-
-:Manual section: 1
+You should have received a copy of the GNU General Public License along
+with this program; if not, see <http://www.gnu.org/licenses/>.

--- a/gen-manpage.sh
+++ b/gen-manpage.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Small script to run rst2man.py and error if there's any output
+set -e
+
+# rst2man.py doesn't return non-zero on warnings or errors 🤦
+# instead, if it outputs anything on stdout or stderr, assume it's some abnormal
+# result and error
+output="$(rst2man.py $1 $2  2>&1)"
+
+if [ -n "$output" ]; then
+    echo $output && false;
+fi


### PR DESCRIPTION
See #2. The `REAMDE` file is now restored to pure rst format.

Turns out theres a tool called `rst2man(.py)` that can take
specially-crafted .rst files and output a manpage-compatible version of
it (looks like pandoc supports this too via groff which is cool).

Since this tool is distributed via pypi right now, having a man page
format of the help instead of running `dtrx --help` may not be
particularly useful (users need to search out the manpage output 😞 ).

But to prevent it regressing add a CI step to keep rst2man.py working.

Since rst2man.py doesn't support outputting non-zero error code in the
case of non-catastrophic error, check the stderr+stdout of the script;
under zero warnings + errors there should be zero output.

And fix the copyright field in the `README` file to be compatible with
rst2man.py.