### PR TITLE
Gentler exit on missing 'file' command

### DIFF
--- a/dtrx/dtrx.py
+++ b/dtrx/dtrx.py
@@ -1340,9 +1340,15 @@ class ExtractorBuilder(object):
     magic_map_matches = classmethod(magic_map_matches)
 
     def try_by_magic(cls, filename):
-        process = subprocess.Popen(["file", "-zL", filename], stdout=subprocess.PIPE)
-        status = process.wait()
-        if status != 0:
+        try:
+            process = subprocess.Popen(
+                ["file", "-zL", filename], stdout=subprocess.PIPE
+            )
+            status = process.wait()
+            if status != 0:
+                return []
+        except FileNotFoundError:
+            logger.error("'file' command not found, skipping magic test")
             return []
         output = process.stdout.readline().decode("ascii")
         process.stdout.close()

--- a/test.sh
+++ b/test.sh
@@ -26,6 +26,8 @@ case $RUN_JOB in
         # script writes files to an in-tree location, so run serially to avoid
         # clobbering during the tests
         docker run --rm -v "$(pwd)":/mnt/workspace -t "$DOCKER_IMAGE_NAME" bash -c "tox $TOX_ARGS"
+
+        ./tools/test-nonexistent-file-cmd.sh
     ;;
     rst2man)
         # build man page from README

--- a/tools/test-nonexistent-file-cmd.sh
+++ b/tools/test-nonexistent-file-cmd.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# Run a quick test in a docker image that doesn't have the 'file' command
+# installed, and check for any unhandled tracebacks in the output.
+docker run --rm -t --volume "$PWD:/workdir" python:3.10-slim-buster@sha256:ae30f2166f4389e553b642af9f22f7d17ba7fe584e0dd8bf9c75c36d836aabc3 /bin/bash -c "
+cd /workdir && pip install . && touch /tmp/yolo.zip && cd /tmp && dtrx yolo.zip 2>&1 | tee /dev/stderr | ( ! grep 'Traceback (most recent call last):')
+"


### PR DESCRIPTION
`dtrx` exits quite abruptly with a traceback if the `file` command is
not present on the host (for example, on the docker image
`python:3.10-slim-buster`).

Add a fix to more gently exit with a message on this event:

```bash
dtrx: ERROR: 'file' command not found, skipping magic test
```

Add a pretty janky test to ensure it stays fixed.

Fixes #24
