### PR TITLE
Python 3.10 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
     strategy:
       matrix:
-        python: [py27, py36, py37, py38, py39]
+        python: [py27, py36, py37, py38, py39, py3.10]
 
     steps:
       # checkout v2, with recursive submodule update

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.7{,-dev,-distutils} \
     python3.8{,-dev} \
     python3.9{,-dev,-distutils}\
+    python3.10{,-dev,-distutils}\
     python3-distutils" \
     && rm -rf /var/lib/apt/lists/*
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,11 @@ dtrx-8.2.2-py2.py3-none-any.whl  dtrx-8.2.2.tar.gz
 
 # optional, but nice to do, create a GitHub Release for the tag. requires
 # permissions on the dtrx GitHub repo
-❯ gh release create --generate-notes <tag>
+❯ export DTRX_TAGNAME=$(python -c 'from dtrx import dtrx; print(dtrx.VERSION)')
+❯ gh release create --generate-notes ${DTRX_TAGNAME}
+# generate a zipapp too!
+❯ python -m zipapp dtrx --compress --main "dtrx:main" --python "/usr/bin/env python" --output dtrx-${DTRX_TAGNAME}
+❯ gh release upload ${DTRX_TAGNAME} dist/* dtrx.pyz
 ```
 
 ### Tests

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,6 @@ case $RUN_JOB in
         docker run --rm -v "$(pwd)":/workspace -t "$DOCKER_IMAGE_NAME" bash -c "tox $TOX_ARGS"
 
         ./tools/test-nonexistent-file-cmd.sh
-        docker run --rm -v "$(pwd)":/workspace -t "$DOCKER_IMAGE_NAME" bash -c "tox $TOX_ARGS"
     ;;
     quick-test)
         # single quick test

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 requires = [ "setuptools == 40.6.3", "wheel == 0.32.3"]
 
 [tox]
-envlist = py27, py36, py37, py38, py39
+envlist = py27, py36, py37, py38, py39, py3.10
 
 [testenv]
 whitelist_externals =


### PR DESCRIPTION
Actually run it in tox + ci, since it's in the classifiers list.

Also add a note in the README about uploading github release artifacts,
and fix a duplicate tox run in test.sh.
