### PR TITLE
Fixes for 7z

### DIFF
--- a/dtrx/dtrx.py
+++ b/dtrx/dtrx.py
@@ -764,7 +764,7 @@ class ZstandardExtractor(NoPipeExtractor):
                 if fn_index is not None:
                     break
                 else:
-                    fn_index = string.rindex(line, " ") + 1
+                    fn_index = line.rindex(" ") + 1
             elif fn_index is not None:
                 yield line[fn_index:]
         self.archive.close()

--- a/dtrx/dtrx.py
+++ b/dtrx/dtrx.py
@@ -713,8 +713,10 @@ class LZHExtractor(ZipExtractor):
 
 class SevenExtractor(NoPipeExtractor):
     file_type = "7z file"
-    list_command = ["7z", "l"]
+    list_command = ["7z", "l", "-ba"]
     border_re = re.compile("^[- ]+$")
+    extract_command = ["7z", "x"]
+    space_re = re.compile(" ")
 
     @property
     def extract_command(self):
@@ -727,15 +729,10 @@ class SevenExtractor(NoPipeExtractor):
         return cmd
 
     def get_filenames(self):
-        fn_index = None
         for line in NoPipeExtractor.get_filenames(self):
-            if self.border_re.match(line):
-                if fn_index is not None:
-                    break
-                else:
-                    fn_index = string.rindex(line, " ") + 1
-            elif fn_index is not None:
-                yield line[fn_index:]
+            if " " in line:
+                pos = line.rindex(" ") + 1
+                yield line[pos:]
         self.archive.close()
 
     def send_stdout_to_dev_null(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ build==0.8.0
 docutils==0.16
 invoke==1.7.1
 pre-commit==2.20.0
-pyyaml==5.4.1
+pyyaml==5.3.1
 tox==3.26.0
 tox-pyenv==1.1.0

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -312,6 +312,19 @@
     a/b
     foobar
 
+- name: list contents of 7z
+  options: -n -l
+  filenames: test-1.23.7z
+  output: |
+    test-1.23.7z:
+    test-1.23/1/2/3
+    test-1.23/a/b
+    test-1.23/foobar
+    test-1.23/a
+    test-1.23/1/2
+    test-1.23/1
+    test-1.23
+
 - name: list contents of .arj
   options: -n -l
   filenames: test-1.23.arj

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist = py27, py37, py38, py39, py3.10, py3.11
 whitelist_externals =
     /bin/bash
 deps =
-    pyyaml==5.4.1
+    pyyaml==5.3.1
 setenv =
     TOX_INI_DIR = {toxinidir}
 commands =


### PR DESCRIPTION
This fixes #48 .

I removed another use of "string.rindex" at the same time -- I can't actually make the code execute, but it might be I just couldn't figure out how to do it, and I certainly haven't made the code worse by removing an invalid function. Also added text.

I actually changed how 7z reads files, as once I fixed the `string.rindex` code, the result still didn't work. Added a test.