### PR TITLE
Fix CI

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ build==0.8.0
 docutils==0.16
 invoke==1.7.1
 pre-commit==2.20.0
-pyyaml==5.4.1
+pyyaml==5.3.1
 tox==3.26.0
 tox-pyenv==1.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ envlist = py27, py37, py38, py39, py3.10, py3.11
 whitelist_externals =
     /bin/bash
 deps =
-    pyyaml==5.4.1
+    pyyaml==5.3.1
 setenv =
     TOX_INI_DIR = {toxinidir}
 commands =


### PR DESCRIPTION
The version of pyyaml we use was failing due to a cython related issue. After a quick google, the easiest option seems to be to go to an even older version -- that fixes CI on all versions we support, and pyyaml is only used for testing, so it doesn't matter it's old and insecure.