### PR TITLE
fix .tar.lz mapping

### DIFF
--- a/dtrx/dtrx.py
+++ b/dtrx/dtrx.py
@@ -1350,7 +1350,7 @@ class ExtractorBuilder(object):
         ("tar", "gzip", "tar.gz", "tgz"),
         ("tar", "lzma", "tar.lzma", "tlz"),
         ("tar", "xz", "tar.xz", "txz"),
-        ("tar", "lz", "tar.lz"),
+        ("tar", "lzip", "tar.lz"),
         ("tar", "compress", "tar.Z", "taz"),
         ("tar", "lrz", "tar.lrz"),
         ("tar", "zstd", "tar.zst"),


### PR DESCRIPTION
there is no 'lz' encoding, but rather `lzip` encoding.

this code path isn't normally exercised, because proper .tar.lz files are handled by the magic bytes decoder. to see what this fixes, pass dtrx an archive which ends in `.tar.lz` but is _not_ a lzip'd tarball.

previously, the following causes an abort:
```
$ mkdir foo
$ touch foo/bar
$ tar --lzma -cf foo.tar.lz foo
$ dtrx -vv foo.tar.lz
dtrx: DEBUG: logger is set up
dtrx: DEBUG: getting extractors by mimetype
dtrx: DEBUG: done getting extractors
dtrx: DEBUG: trying ('tar', 'lzip') extractor from mimetype
dtrx: DEBUG: running command: ['lzip', '-cd']
dtrx: DEBUG: running command: ['tar', '-x']
dtrx: DEBUG: success results: False 0 [2, 2]
dtrx: DEBUG: Traceback (most recent call last):
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/lib/python3.12/site-packages/dtrx/dtrx.py", line 1424, in report
    error = function(*args)
            ^^^^^^^^^^^^^^^
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/lib/python3.12/site-packages/dtrx/dtrx.py", line 433, in extract
    self.check_success(self.content_type != EMPTY)
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/lib/python3.12/site-packages/dtrx/dtrx.py", line 411, in check_success
    raise ExtractorError(
dtrx.dtrx.ExtractorError: decoding error: 'lzip -cd' returned status code 2

dtrx: DEBUG: getting extractors by extension
dtrx: DEBUG: done getting extractors
dtrx: DEBUG: trying ('tar', 'lz') extractor from extension
Traceback (most recent call last):
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/bin/.dtrx-wrapped", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/lib/python3.12/site-packages/dtrx/dtrx.py", line 1811, in main
    sys.exit(app.run())
             ^^^^^^^^^
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/lib/python3.12/site-packages/dtrx/dtrx.py", line 1794, in run
    error = self.check_file(filename) or self.try_extractors(
                                         ^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/lib/python3.12/site-packages/dtrx/dtrx.py", line 1736, in try_extractors
    for extractor in builder:
                     ^^^^^^^
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/lib/python3.12/site-packages/dtrx/dtrx.py", line 1358, in get_extractor
    for extractor in self.build_extractor(*ext_args):
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/lib/python3.12/site-packages/dtrx/dtrx.py", line 1340, in build_extractor
    yield extractor(self.filename, encoding)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/2kgqrj54ihs9l21v8fplaxd2j100g6hv-dtrx-8.5.3/lib/python3.12/site-packages/dtrx/dtrx.py", line 236, in __init__
    raise ValueError("unrecognized encoding %s" % (encoding,))
ValueError: unrecognized encoding lz
```

after this change, the archive is correctly extracted (after attempting magic bytes extraction, followed by extension-based extraction, followed finally by mime-based extraction -- the last which recognizes this as lzma instead of lzip).