### PR TITLE
FAT Disk Image Extractor using mtools.

### DIFF
--- a/dtrx/dtrx.py
+++ b/dtrx/dtrx.py
@@ -616,7 +616,7 @@ class FATDiskImageExtractor(NoPipeExtractor):
         self.list_pipe = command
         for line in NoPipeExtractor.get_filenames(self):
             # mtools prefixes with ::/ for the default drive, remove that.
-            yield re.sub(r'^::[/\\]', '', line)
+            yield re.sub(r"^::[/\\]", "", line)
         self.archive.close()
 
 
@@ -1183,7 +1183,7 @@ class ExtractorBuilder(object):
         "fat": {
             "extractors": (FATDiskImageExtractor,),
             "mimetypes": ("x-msdos", "x-fat"),
-            "extensions": ("img", "ima", "vfd"),
+            "extensions": ("ima", "vfd"),
             "magic": ("DOS/MBR boot sector", "FAT12", "FAT16", "FAT32"),
         },
         "zip": {

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -945,6 +945,7 @@
     gem
     gz
     hdr
+    ima
     jar
     lha
     lrz
@@ -970,6 +971,7 @@
     tgz
     tlz
     txz
+    vfd
     xpi
     xz
     zip


### PR DESCRIPTION
Extract from FAT disk images using mtools commands `mdir` and `mcopy`.