### PR TITLE
Remove incorrect README link, add url to @brettcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,9 @@ dtrx yolo.tar.gz
 ```
 
 This is a copy-paste of the original dtrx repo, and **all credit for this
-software** should be attributed to the original author, Brett Smith @brettcs:
+software** should be attributed to the original author, Brett Smith [@brettcs](https://github.com/brettcs):
 
 https://github.com/brettcs/dtrx
-
-See the original [`README`](README) for more details on what this does!
 
 ## Changes in this repo
 


### PR DESCRIPTION
* Remove incorrect README link which pointed to this repository, the link to the original repository already previews the old README
* Make `@brettcs` a link to the profile page as READMEs don't do that automatically

Superceeds https://github.com/dtrx-py/dtrx/pull/72